### PR TITLE
Add pipes support for stdin JavaScript execution

### DIFF
--- a/bunosh.js
+++ b/bunosh.js
@@ -1,63 +1,123 @@
 #!/usr/bin/env bun
+
+// Check for piped input FIRST, before any other imports
+function isPipeInput() {
+  // In Bun, process.stdin.isTTY is undefined when piped, not false
+  return process.stdin.isTTY === undefined || !process.stdin.isTTY;
+}
+
+// Read stdin immediately if piped input detected, before other modules can interfere
+let stdinData = null;
+if (isPipeInput()) {
+  // Use synchronous reading to avoid any timing issues
+  try {
+    const fs = require('fs');
+    const buffer = Buffer.alloc(64 * 1024); // 64KB buffer
+    const bytesRead = fs.readSync(0, buffer, 0, buffer.length, null);
+    stdinData = buffer.toString('utf8', 0, bytesRead).trim();
+  } catch (error) {
+    console.error('Error reading stdin:', error.message);
+    stdinData = '';
+  }
+}
+
 import program, { BUNOSHFILE, banner }  from "./src/program.js";
 import { existsSync, readFileSync, statSync } from "fs";
 import init from "./src/init.js";
 import path from "path";
 import color from "chalk";
-import './index.js';
 
-// Parse --bunoshfile flag before importing tasks
-const bunoshfileIndex = process.argv.indexOf('--bunoshfile');
-let customBunoshfile = null;
-if (bunoshfileIndex !== -1 && bunoshfileIndex + 1 < process.argv.length) {
-  customBunoshfile = process.argv[bunoshfileIndex + 1];
-  // Remove the flag and its value from process.argv so it doesn't interfere with command parsing
-  process.argv.splice(bunoshfileIndex, 2);
-}
 
-let tasksFile;
-if (customBunoshfile) {
-  const resolvedPath = path.isAbsolute(customBunoshfile) ? customBunoshfile : path.resolve(customBunoshfile);
-  // If it's a directory, append the default BUNOSHFILE
-  if (existsSync(resolvedPath) && statSync(resolvedPath).isDirectory()) {
-    tasksFile = path.join(resolvedPath, BUNOSHFILE);
-    // Change working directory to the bunoshfile directory
-    process.chdir(resolvedPath);
+async function main() {
+  // Parse --bunoshfile flag before importing tasks
+  const bunoshfileIndex = process.argv.indexOf('--bunoshfile');
+  let customBunoshfile = null;
+  if (bunoshfileIndex !== -1 && bunoshfileIndex + 1 < process.argv.length) {
+    customBunoshfile = process.argv[bunoshfileIndex + 1];
+    // Remove the flag and its value from process.argv so it doesn't interfere with command parsing
+    process.argv.splice(bunoshfileIndex, 2);
+  }
+
+  let tasksFile;
+  if (customBunoshfile) {
+    const resolvedPath = path.isAbsolute(customBunoshfile) ? customBunoshfile : path.resolve(customBunoshfile);
+    // If it's a directory, append the default BUNOSHFILE
+    if (existsSync(resolvedPath) && statSync(resolvedPath).isDirectory()) {
+      tasksFile = path.join(resolvedPath, BUNOSHFILE);
+      // Change working directory to the bunoshfile directory
+      process.chdir(resolvedPath);
+    } else {
+      tasksFile = resolvedPath;
+      // Change working directory to the bunoshfile's directory
+      process.chdir(path.dirname(resolvedPath));
+    }
   } else {
-    tasksFile = resolvedPath;
-    // Change working directory to the bunoshfile's directory
-    process.chdir(path.dirname(resolvedPath));
-  }
-} else {
-  tasksFile = path.join(process.cwd(), BUNOSHFILE);
-}
-
-if (!existsSync(tasksFile)) {
-  banner();
-
-  if (process.argv.includes('init')) {
-    init();
-    process.exit(0);
+    tasksFile = path.join(process.cwd(), BUNOSHFILE);
   }
 
-  console.log();
-  console.error(`Bunoshfile not found: ${tasksFile}`);
-  console.log(customBunoshfile ? 
-    `Run \`bunosh init\` in the directory or specify a valid --bunoshfile path` :
-    "Run `bunosh init` to create a new Bunoshfile here")
-  console.log();
-  process.exit(1);
-}
+  // Handle piped input first
+  if (isPipeInput()) {
+    const jsCode = stdinData;
+    if (!jsCode) {
+      console.error('No JavaScript code provided via stdin');
+      process.exit(1);
+    }
+    
+    try {
+      // Import bunosh globals before executing piped JavaScript
+      await import('./index.js');
+      
+      // Execute the piped JavaScript code with bunosh globals available
+      const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
+      
+      // Make bunosh globals available to the function by destructuring from global.bunosh
+      const globalVars = Object.keys(global.bunosh).map(key => `const ${key} = global.bunosh.${key};`).join('\n');
+      const funcBody = `${globalVars}\n${jsCode}`;
+      
+      const func = new AsyncFunction(funcBody);
+      await func();
+    } catch (error) {
+      console.error('Error executing piped JavaScript:', error.message);
+      process.exit(1);
+    }
+    return;
+  }
 
-import(tasksFile).then((tasks) => {
-  try {
-    const source = readFileSync(tasksFile, "utf-8");
-    program(tasks, source);
-  } catch (error) {
+  if (!existsSync(tasksFile)) {
+    banner();
+
+    if (process.argv.includes('init')) {
+      init();
+      process.exit(0);
+    }
+
+    console.log();
+    console.error(`Bunoshfile not found: ${tasksFile}`);
+    console.log(customBunoshfile ? 
+      `Run \`bunosh init\` in the directory or specify a valid --bunoshfile path` :
+      "Run `bunosh init` to create a new Bunoshfile here")
+    console.log();
+    process.exit(1);
+  }
+
+  // Import bunosh globals for normal operation
+  await import('./index.js');
+  
+  import(tasksFile).then((tasks) => {
+    try {
+      const source = readFileSync(tasksFile, "utf-8");
+      program(tasks, source);
+    } catch (error) {
+      handleBunoshfileError(error, tasksFile);
+    }
+  }).catch((error) => {
     handleBunoshfileError(error, tasksFile);
-  }
-}).catch((error) => {
-  handleBunoshfileError(error, tasksFile);
+  });
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error.message);
+  process.exit(1);
 });
 
 function handleBunoshfileError(error, filePath) {

--- a/test/pipes.test.js
+++ b/test/pipes.test.js
@@ -1,0 +1,198 @@
+import { describe, test, expect, mock, spyOn } from 'bun:test';
+import { spawn } from 'bun';
+import path from 'path';
+
+const bunoshPath = path.resolve('./bunosh.js');
+
+describe('Pipes Support', () => {
+  test('executes simple JavaScript code from stdin', async () => {
+    const proc = spawn({
+      cmd: ['bun', bunoshPath],
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe'
+    });
+
+    proc.stdin?.write('console.log("Hello from pipe");');
+    proc.stdin?.end();
+
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('Hello from pipe');
+  });
+
+  test('executes bunosh functions from stdin', async () => {
+    const proc = spawn({
+      cmd: ['bun', bunoshPath],
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe'
+    });
+
+    proc.stdin?.write('say("Test message from pipe");');
+    proc.stdin?.end();
+
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('Test message from pipe');
+  });
+
+  test('executes exec command from stdin', async () => {
+    const proc = spawn({
+      cmd: ['bun', bunoshPath],
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe'
+    });
+
+    proc.stdin?.write('exec`echo "Command executed via pipe"`;');
+    proc.stdin?.end();
+
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('Command executed via pipe');
+    expect(output).toContain('✓ exec echo'); // Task completion indicator
+  });
+
+  test('handles multiple statements from stdin', async () => {
+    const proc = spawn({
+      cmd: ['bun', bunoshPath],
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe'
+    });
+
+    const code = `
+      say('Starting tasks...');
+      exec\`echo "First command"\`;
+      say('Tasks completed!');
+    `;
+    
+    proc.stdin?.write(code);
+    proc.stdin?.end();
+
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('Starting tasks...');
+    expect(output).toContain('First command');
+    expect(output).toContain('Tasks completed!');
+  });
+
+  test('handles syntax errors in piped code', async () => {
+    const proc = spawn({
+      cmd: ['bun', bunoshPath],
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe'
+    });
+
+    proc.stdin?.write('invalid javascript syntax {{{');
+    proc.stdin?.end();
+
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('Error executing piped JavaScript');
+  });
+
+  test('handles empty stdin input', async () => {
+    const proc = spawn({
+      cmd: ['bun', bunoshPath],
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe'
+    });
+
+    proc.stdin?.write('');
+    proc.stdin?.end();
+
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('No JavaScript code provided via stdin');
+  });
+
+  test('all bunosh globals are available in piped code', async () => {
+    const proc = spawn({
+      cmd: ['bun', bunoshPath],
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe'
+    });
+
+    const code = `
+      // Test various bunosh globals
+      say('Testing say function');
+      yell('TESTING YELL');
+      exec\`echo "Testing exec"\`;
+      shell\`echo "Testing shell"\`;
+    `;
+    
+    proc.stdin?.write(code);
+    proc.stdin?.end();
+
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('Testing say function');
+    expect(output).toContain('■■■■'); // yell creates ASCII art
+    expect(output).toContain('Testing exec');
+    expect(output).toContain('Testing shell');
+  });
+
+  test('handles async operations in piped code', async () => {
+    const proc = spawn({
+      cmd: ['bun', bunoshPath],
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe'
+    });
+
+    const code = `
+      await exec\`echo "Async command 1"\`;
+      await exec\`echo "Async command 2"\`;
+      say('All async commands completed');
+    `;
+    
+    proc.stdin?.write(code);
+    proc.stdin?.end();
+
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('Async command 1');
+    expect(output).toContain('Async command 2');
+    expect(output).toContain('All async commands completed');
+  });
+
+  test('correctly detects non-pipe input', () => {
+    // Test the isPipeInput function logic
+    // When process.stdin.isTTY is true (terminal), isPipeInput should return false
+    const originalIsTTY = process.stdin.isTTY;
+    
+    // Mock TTY scenario
+    process.stdin.isTTY = true;
+    
+    // Import the isPipeInput function logic inline for testing
+    const isPipeInput = () => {
+      return process.stdin.isTTY === undefined || !process.stdin.isTTY;
+    };
+    
+    expect(isPipeInput()).toBe(false);
+    
+    // Restore original value
+    process.stdin.isTTY = originalIsTTY;
+  });
+});


### PR DESCRIPTION
- Execute Bunosh JavaScript code directly via stdin pipes
- Support for all Bunosh globals (exec, say, shell, etc.) in piped code
- Cross-platform stdin reading with Bun/Node.js compatibility
- Comprehensive test coverage for pipes functionality
- Documentation with GitHub Actions and shell script examples

Examples:
  echo "exec\`ls -la\`; say('done');" | bunosh cat script.js | bunosh

🤖 Generated with [Claude Code](https://claude.ai/code)